### PR TITLE
New feature: Integration of ogbl-vessel specific code

### DIFF
--- a/seal_link_pred.py
+++ b/seal_link_pred.py
@@ -211,7 +211,7 @@ def test():
     elif args.eval_metric == 'mrr':
         results = evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'rocauc':
-        results = evaluate_roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
+        results = evaluate_ogb_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'auc':
         results = evaluate_auc(val_pred, val_true, test_pred, test_true)
 
@@ -262,7 +262,7 @@ def test_multiple_models(models):
             Results.append(evaluate_mrr(pos_val_pred[i], neg_val_pred[i], 
                                         pos_test_pred[i], neg_test_pred[i]))
         elif args.eval_metric == 'rocauc':
-            Results.append(evaluate_rocauc(pos_val_pred[i], neg_val_pred[i], 
+            Results.append(evaluate_ogb_rocauc(pos_val_pred[i], neg_val_pred[i], 
                                         pos_test_pred[i], neg_test_pred[i]))
 
         elif args.eval_metric == 'auc':
@@ -314,7 +314,7 @@ def evaluate_auc(val_pred, val_true, test_pred, test_true):
 
     return results
 
-def evaluate_roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
+def evaluate_ogb_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
     valid_rocauc = evaluator.eval({
         'y_pred_pos': pos_val_pred,
         'y_pred_neg': neg_val_pred,
@@ -502,7 +502,7 @@ if args.use_heuristic:
     elif args.eval_metric == 'mrr':
         results = evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'rocauc':
-        results = evaluate_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
+        results = evaluate_ogb_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'auc':
         val_pred = torch.cat([pos_val_pred, neg_val_pred])
         val_true = torch.cat([torch.ones(pos_val_pred.size(0), dtype=int), 

--- a/seal_link_pred.py
+++ b/seal_link_pred.py
@@ -209,7 +209,7 @@ def test():
     elif args.eval_metric == 'mrr':
         results = evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'rocauc':
-        results = evaluate_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
+        results = evaluate_roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'auc':
         results = evaluate_auc(val_pred, val_true, test_pred, test_true)
 
@@ -311,7 +311,7 @@ def evaluate_auc(val_pred, val_true, test_pred, test_true):
     return results
         
 
-def evaluate roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
+def evaluate_roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
     valid_rocauc = evaluator.eval({
         'y_pred_pos': pos_val_pred,
         'y_pred_neg': neg_val_pred,
@@ -322,7 +322,7 @@ def evaluate roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
             'y_pred_neg': neg_test_pred,
         })[f'rocauc']
 
-    return train_rocauc, valid_rocauc, test_rocauc
+    return valid_rocauc, test_rocauc
 
 # Data settings
 parser = argparse.ArgumentParser(description='OGBL (SEAL)')

--- a/seal_link_pred.py
+++ b/seal_link_pred.py
@@ -208,6 +208,8 @@ def test():
         results = evaluate_hits(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'mrr':
         results = evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
+    elif args.eval_metric == 'rocauc':
+        results = evaluate_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'auc':
         results = evaluate_auc(val_pred, val_true, test_pred, test_true)
 

--- a/seal_link_pred.py
+++ b/seal_link_pred.py
@@ -27,6 +27,8 @@ from torch_geometric.utils import to_networkx, to_undirected
 from ogb.linkproppred import PygLinkPropPredDataset, Evaluator
 
 import warnings
+warnings.filterwarnings("ignore", category=UserWarning)
+
 from scipy.sparse import SparseEfficiencyWarning
 warnings.simplefilter('ignore', SparseEfficiencyWarning)
 
@@ -413,6 +415,11 @@ if args.dataset.startswith('ogbl'):
     dataset = PygLinkPropPredDataset(name=args.dataset)
     split_edge = dataset.get_edge_split()
     data = dataset[0]
+    if args.dataset.startswith('ogbl-vessel'):
+        # normalize node features
+        data.x[:, 0] = torch.nn.functional.normalize(data.x[:, 0], dim=0)
+        data.x[:, 1] = torch.nn.functional.normalize(data.x[:, 1], dim=0)
+        data.x[:, 2] = torch.nn.functional.normalize(data.x[:, 2], dim=0)
 else:
     path = osp.join('dataset', args.dataset)
     dataset = Planetoid(path, args.dataset)

--- a/seal_link_pred.py
+++ b/seal_link_pred.py
@@ -261,6 +261,10 @@ def test_multiple_models(models):
         elif args.eval_metric == 'mrr':
             Results.append(evaluate_mrr(pos_val_pred[i], neg_val_pred[i], 
                                         pos_test_pred[i], neg_test_pred[i]))
+        elif args.eval_metric == 'rocauc':
+            Results.append(evaluate_rocauc(pos_val_pred[i], neg_val_pred[i], 
+                                        pos_test_pred[i], neg_test_pred[i]))
+
         elif args.eval_metric == 'auc':
             Results.append(evaluate_auc(val_pred[i], val_true[i], 
                                         test_pred[i], test_pred[i]))
@@ -283,7 +287,6 @@ def evaluate_hits(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
         results[f'Hits@{K}'] = (valid_hits, test_hits)
 
     return results
-        
 
 def evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
     neg_val_pred = neg_val_pred.view(pos_val_pred.shape[0], -1)
@@ -300,7 +303,6 @@ def evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
     })['mrr_list'].mean().item()
 
     results['MRR'] = (valid_mrr, test_mrr)
-    
     return results
 
 
@@ -311,7 +313,6 @@ def evaluate_auc(val_pred, val_true, test_pred, test_true):
     results['AUC'] = (valid_auc, test_auc)
 
     return results
-        
 
 def evaluate_roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
     valid_rocauc = evaluator.eval({
@@ -324,7 +325,9 @@ def evaluate_roc_auc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred):
             'y_pred_neg': neg_test_pred,
         })[f'rocauc']
 
-    return valid_rocauc, test_rocauc
+    results = {}
+    results['rocauc'] = (valid_rocauc, test_rocauc)
+    return results
 
 # Data settings
 parser = argparse.ArgumentParser(description='OGBL (SEAL)')
@@ -460,6 +463,11 @@ elif args.eval_metric == 'mrr':
     loggers = {
         'MRR': Logger(args.runs, args),
     }
+elif args.eval_metric == 'rocauc':
+    loggers = {
+        'rocauc': Logger(args.runs, args),
+    }
+
 elif args.eval_metric == 'auc':
     loggers = {
         'AUC': Logger(args.runs, args),
@@ -493,6 +501,8 @@ if args.use_heuristic:
         results = evaluate_hits(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'mrr':
         results = evaluate_mrr(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
+    elif args.eval_metric == 'rocauc':
+        results = evaluate_rocauc(pos_val_pred, neg_val_pred, pos_test_pred, neg_test_pred)
     elif args.eval_metric == 'auc':
         val_pred = torch.cat([pos_val_pred, neg_val_pred])
         val_true = torch.cat([torch.ones(pos_val_pred.size(0), dtype=int), 

--- a/utils.py
+++ b/utils.py
@@ -236,13 +236,17 @@ def do_edge_split(dataset, fast_split=False, val_ratio=0.05, test_ratio=0.1):
 def get_pos_neg_edges(split, split_edge, edge_index, num_nodes, percent=100):
     if 'edge' in split_edge['train']:
         pos_edge = split_edge[split]['edge'].t()
-        if split == 'train':
+
+        if 'edge_neg' in split_edge['train']:
+            # use presampled  negative training edges for ogbl-vessel
+            neg_edge = split_edge[split]['edge_neg'].t()
+
+        else:
             new_edge_index, _ = add_self_loops(edge_index)
             neg_edge = negative_sampling(
                 new_edge_index, num_nodes=num_nodes,
                 num_neg_samples=pos_edge.size(1))
-        else:
-            neg_edge = split_edge[split]['edge_neg'].t()
+
         # subsample for pos_edge
         np.random.seed(123)
         num_pos = pos_edge.size(1)


### PR DESCRIPTION
Hi SEAL team,

we are currently moving towards the official release of [ogbl-vessel](https://ogb.stanford.edu/docs/linkprop/#ogbl-vessel) and would be very happy to have SEAL on the official leaderboard. Thus, I implemented some changes to the current code base to support the new graph. Please consider reviewing the changes and pushing the code to the main branch, if you are interested in supporting ogbl-vessel as well :slightly_smiling_face:. If you find anything that does not make sense or if you do think it does not make sense to merge this into main, please let me know! I am also happy to answer any questions regarding code and graph! :slightly_smiling_face: 

As `ogbl-vessel` uses the ROCAUC metric and we provide presampled negative training edges, I changed the code base of SEAL_OGB w.r.t. the following things: 

1. `seal_link_pred.py`: In addition to the rocauc function, we use a new function `evaluate_ogb_rocauc` for the ogb evaluator. I kept the old function `evaluate_auc` to support non-OGB graphs as well, as these differ slightly.
2.  `seal_link_pred.py`: Normalization of ogbl-vessel node features. 
3. `utils.py`: Use negative training samples if available.

Thank you,

Julian