### PR TITLE
Fixing the bug mentioned in: 

### DIFF
--- a/seal_link_pred.py
+++ b/seal_link_pred.py
@@ -448,8 +448,9 @@ if args.use_valedges_as_input:
     if not directed:
         val_edge_index = to_undirected(val_edge_index)
     data.edge_index = torch.cat([data.edge_index, val_edge_index], dim=-1)
-    val_edge_weight = torch.ones([val_edge_index.size(1), 1], dtype=int)
-    data.edge_weight = torch.cat([data.edge_weight, val_edge_weight], 0)
+    if 'edge_weight' in data:
+        val_edge_weight = torch.ones([data.edge_index.size(1), 1], dtype=int)
+        data.edge_weight = torch.cat([data.edge_weight, val_edge_weight], 0)
 
 if args.dataset.startswith('ogbl'):
     evaluator = Evaluator(name=args.dataset)


### PR DESCRIPTION
As mentioned in the following issue: https://github.com/facebookresearch/SEAL_OGB/issues/37#issue-1682442949, an error occurs when using validation edges as input on the ogbl-ppa dataset:
```
Traceback (most recent call last):
    File "./SEAL_OGB/seal_link_pred.py", line 452, in <module>
        data.edge_weight = torch.cat([data.edge_weight, val_edge_weight], 0)
TypeError: expected Tensor as element 0 in argument 0, but got NoneType
```
The reason is that ogbl-ppa dataset's edge_weight=None. To fix this bug, we need to check if the datasets contains edge_weights:
```
if 'edge_weight' in data:
    val_edge_weight = torch.ones([data.edge_index.size(1), 1], dtype=int)
    data.edge_weight = torch.cat([data.edge_weight, val_edge_weight], 0)
```